### PR TITLE
Start to remove calls to state()

### DIFF
--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -347,7 +347,7 @@ const app = {
             },
             changeLayerVariable: (domain, variable) => {
                 update({layers: { [domain]: { variable }}})
-                actions.fetchLayerData(domain)
+                actions.fetchLayerData(domain, states())
             },
             setCompare: compare => {
                 update({
@@ -363,7 +363,7 @@ const app = {
             },
             setLTypes: LTypes => {
                 update({desiredLTypes: LTypes})
-                actions.fetchLayerData("links")
+                actions.fetchLayerData("links", states())
             },
             getMeta: async () => {
                 const [links, od_matrices, scenarios] =
@@ -394,18 +394,15 @@ const app = {
                 zoneCentres: await getData("centroids")
             }),
             fetchAllLayers: () => {
-                actions.fetchLayerData("links")
-                actions.fetchLayerData("od_matrices")
+                actions.fetchLayerData("links", states())
+                actions.fetchLayerData("od_matrices", states())
             },
             toggleCentroids: showness => {
                 update({showClines: showness})
             },
-            clickZone: event => {
-                const state = states()
+            clickZone: (event, selectedZones) => {
                 const fid = event.features[0].properties.fid
                 const ctrlPressed = event.originalEvent.ctrlKey
-
-                let selectedZones = state.selectedZones.slice()
 
                 if (selectedZones.includes(fid)) {
                     selectedZones = ctrlPressed ? selectedZones.filter(x => x !== fid) : []
@@ -427,12 +424,12 @@ const app = {
                 if (oldcompare) {
                     actions.fetchAllLayers()
                 } else {
-                    actions.fetchLayerData("od_matrices")
+                    actions.fetchLayerData("od_matrices", states())
                 }
             },
-            fetchLayerData: async domain => {
-
-                const state = states()
+            fetchLayerData: async (domain, {
+                compare, compareYear, scenario, scenarioYear: year, meta, selectedZones, compareWith, percent, layers // Unpack state object so we know what is used
+            })   => {
 
                 const updateLayer = patch =>
                     update({
@@ -441,7 +438,7 @@ const app = {
                         }
                     })
 
-                const variable = state.layers[domain].variable
+                const variable = layers[domain].variable
 
                 if (!variable) {
                     return updateLayer({
@@ -454,18 +451,17 @@ const app = {
                 }
 
                 // Else fetch data
-                const {compare, compareYear, scenario, scenarioYear: year, meta} = state
-                const compareWith = compare ? state.compareWith : "none"
-                const percent = compare && state.percent
+                compareWith = compare ? compareWith : "none"
+                percent = compare && percent
                 let bounds, values, basevalues
 
-                const dir = state.compare ? meta[domain][variable]["good"] :
+                const dir = compare ? meta[domain][variable]["good"] :
                     meta[domain][variable]["reverse_palette"] ? "smaller" : "bigger"
                 const unit = getUnit(meta, domain, variable, percent)
 
-                if (domain === "od_matrices" && state.selectedZones.length !== 0) {
+                if (domain === "od_matrices" && selectedZones.length !== 0) {
                     ;[values, basevalues] = await Promise.all([
-                        getData("data?domain=od_matrices&year=" + year + "&variable=" + variable + "&scenario=" + scenario + "&comparewith=" + compareWith + "&compareyear=" + compareYear + "&row=" + state.selectedZones), // Compare currently unused
+                        getData("data?domain=od_matrices&year=" + year + "&variable=" + variable + "&scenario=" + scenario + "&comparewith=" + compareWith + "&compareyear=" + compareYear + "&row=" + selectedZones), // Compare currently unused
                         getData("data?domain=od_matrices&year=" + year + "&variable=" + variable + "&scenario=" + scenario + "&comparewith=" + compareWith + "&compareyear=" + compareYear)
                     ])
 
@@ -473,7 +469,7 @@ const app = {
                     const sortedValues = sort(values)
                     bounds = [ d3.quantile(sortedValues, 0.1), d3.quantile(sortedValues, 0.9) ]
 
-                    const centroidLineWeights = await Promise.all(state.selectedZones.map(async zone => getData("data?domain=od_matrices&year=" + year + "&variable=" + variable + "&scenario=" + scenario + "&comparewith=" + compareWith + "&compareyear=" + compareYear + "&row=" + zone))) // values, not weights any more
+                    const centroidLineWeights = await Promise.all(selectedZones.map(async zone => getData("data?domain=od_matrices&year=" + year + "&variable=" + variable + "&scenario=" + scenario + "&comparewith=" + compareWith + "&compareyear=" + compareYear + "&row=" + zone))) // values, not weights any more
 
                     const palette = d3.scaleSequential(
                         dir == "smaller" ? R.reverse(bounds) : bounds,
@@ -507,7 +503,7 @@ const app = {
                     // Quantiles should be overridden by metadata
                     ;[bounds, values, basevalues] = await Promise.all([
                         // Clamp at 99.99% and 0.01% quantiles
-                        (state.compare || R.equals(state.meta[domain][variable].force_bounds,[])) ? getData("stats?domain=" + domain + "&variable=" + variable + `&quantiles=${qs[0]},${qs[1]}` + "&comparewith=" + compareWith + "&compareyear=" + compareYear + "&percent=" + percent) : state.meta[domain][variable].force_bounds,
+                        (compare || R.equals(meta[domain][variable].force_bounds,[])) ? getData("stats?domain=" + domain + "&variable=" + variable + `&quantiles=${qs[0]},${qs[1]}` + "&comparewith=" + compareWith + "&compareyear=" + compareYear + "&percent=" + percent) : meta[domain][variable].force_bounds,
                         getData("data?domain=" + domain + "&year=" + year + "&variable=" + variable + "&scenario=" + scenario + "&percent=" + percent + "&comparewith=" + compareWith + "&compareyear=" + compareYear),
                         domain == "od_matrices" && getData("data?domain=od_matrices&year=" + year + "&variable=" + variable + "&scenario=" + scenario + "&comparewith=" + compareWith + "&compareyear=" + compareYear)
                     ])
@@ -631,7 +627,9 @@ const { update, states, actions } =
     map.on("moveend", positionUpdate)
     map.on("zoomend", positionUpdate)
 
-    map.on('click', 'zones', actions.clickZone)
+    map.on('click', 'zones', event => (
+        (event, state) => actions.clickZone(event,state.selectedZones)
+    )(event,states())) // As below - need a tidier way of getting global state into this function
 
     map.on('click', 'links', async event => ((event, state) => {
         update({
@@ -982,7 +980,7 @@ const menuView = state => {
                                             selectedZones: [],
                                             centroidLineWeights: null,
                                         })
-                                        actions.fetchLayerData("od_matrices")
+                                        actions.fetchLayerData("od_matrices", state)
                                     }}),
                             ')'),
                             m('label', {for: 'show_clines'}, 'Flow lines: ',
@@ -1096,21 +1094,18 @@ function setColours(nums, colour) {
         ['to-color', atFid(colours)])
 }
 
-function setLinkColours(nums, colour,weights) {
+function setLinkColours(nums, colour, weights, {compare, percent, meta, layers, desiredLTypes, LTypes}) {
     const colours = nums.map(colour)
-    const state = states() // This is not kosher
-
     const magic_multiplier = 0.1 // Multiplier to make tuning thickness of all lines together easier
-    if (!state.percent && state.meta.links[state.layers.links.variable].thickness !== "const") { // TODO: fix this so it looks good enough to use for percentages (10x decrease should be about as obvious as 10x increase)
-        let [q1, q2] = state.compare ? 
-            state.percent ? 
+    if (!percent && meta.links[layers.links.variable].thickness !== "const") { // TODO: fix this so it looks good enough to use for percentages (10x decrease should be about as obvious as 10x increase)
+        let [q1, q2] = compare ? 
+            percent ? 
                 [0.15, 0.85] :
                 [0.01, 0.99] :
             [0.001, 0.999]
         let bounds = [d3.quantile(sort(weights),q1),d3.quantile(sort(weights),q2)]
 
-        const COMPARE_MODE = state.compare
-        const percent = state.percent
+        const COMPARE_MODE = compare
 
         if (COMPARE_MODE) {
             const maxb = Math.max(...(bounds.map(Math.abs)))
@@ -1151,9 +1146,9 @@ function setLinkColours(nums, colour,weights) {
     //     /* fallback */ .8
     // ])
 
-    if (!R.equals(state.desiredLTypes, [])) {
-        const opacities = state.LTypes.map(x => {
-            return R.includes(x,state.desiredLTypes) ? 1 : 0
+    if (!R.equals(desiredLTypes, [])) {
+        const opacities = LTypes.map(x => {
+            return R.includes(x,desiredLTypes) ? 1 : 0
         })
         map.setPaintProperty("links", "line-opacity", atId(opacities))
     } else {
@@ -1272,7 +1267,7 @@ function paint(domain, {variable, values, bounds, dir, palette}) {
         if (domain == "od_matrices"){
             setColours(values, palette[0])
         } else {
-            setLinkColours(values, palette[0],values)
+            setLinkColours(values, palette[0],values, states())
         }
         map.setLayoutProperty(mapLayers[domain], "visibility", "visible")
     }
@@ -1293,12 +1288,10 @@ function getPalette(preferred, compare) {
     }
 }
 
-async function getDataFromId(id,domain="links"){
-    const state = states()
-    const variable = state.layers[domain].variable
-    log("state is ", state)
-    const percData = await getData("data?domain=" + domain + "&year="+ state.scenarioYear + "&variable=" + variable + "&scenario=" + state.scenario + "&percent=true")
-    const absData = await getData("data?domain=" + domain + "&year=" + state.scenarioYear + "&variable=" + variable + "&scenario=" + state.scenario + "&percent=false")
+async function getDataFromId(id, domain="links", {layers, scenarioYear, scenario} = states()){
+    const variable = layers[domain].variable
+    const percData = await getData("data?domain=" + domain + "&year="+ scenarioYear + "&variable=" + variable + "&scenario=" + scenario + "&percent=true")
+    const absData = await getData("data?domain=" + domain + "&year=" + scenarioYear + "&variable=" + variable + "&scenario=" + scenario + "&percent=false")
     return {absVal: absData[id], percVal: percData[id]}
 }
 


### PR DESCRIPTION
This starts to adopt a convention where state is unpacked in
function arguments so that new parts of state can be accessed
easily by adding them to the function signature.

This way we can easily see which parts of the state are used
in a function without having to rewrite the calls to that
function every time we want to access more state.