### PR TITLE
rework zone selection list

### DIFF
--- a/src/frontend/js/index.html
+++ b/src/frontend/js/index.html
@@ -22,6 +22,9 @@ body { margin:0; padding:0; }
     float: right;
     font-size: small;
 }
+.gcvt-ctrl label {
+    margin-top: .5rem;
+}
 .gcvt-ctrl button {
     width: 100%;
     margin-top: 5px;

--- a/src/frontend/js/index.html
+++ b/src/frontend/js/index.html
@@ -5,9 +5,6 @@
 <title>Greener Connectivity Visualisation Tool</title>
 <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css' rel='stylesheet' />
-<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.css">
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/milligram/1.3.0/milligram.css">
 <link rel="stylesheet" type="text/css" href="../node_modules/construct-ui/lib/index.css">
 <link rel="alternate" type="application/json+oembed" href="//MAGIC_NGINX_REWRITE_EMBED_URL_HERE.com">
 <style>

--- a/src/frontend/js/index.html
+++ b/src/frontend/js/index.html
@@ -35,11 +35,6 @@ body { margin:0; padding:0; }
 .flowlistholder {
     margin-top: 10px;
 }
-.flowlistholder span {
-    font-size: 1.6rem;
-    font-weight: 700;
-    margin-bottom: .5rem;
-}
 .flowlistholder ul {
     list-style-type: none;
 }
@@ -48,6 +43,11 @@ body { margin:0; padding:0; }
 }
 .flowlistholder input {
     margin-right: 5px;
+}
+.flowlistheader {
+    font-size: 1.6rem;
+    font-weight: 700;
+    margin-bottom: .5rem;
 }
 </style>
 </head>

--- a/src/frontend/js/index.html
+++ b/src/frontend/js/index.html
@@ -22,12 +22,6 @@ body { margin:0; padding:0; }
     float: right;
     font-size: small;
 }
-.gcvt-ctrl ul {
-    list-style-type: none;
-}
-.gcvt-ctrl ul li {
-    margin-bottom: 0;
-}
 .gcvt-ctrl button {
     width: 100%;
     margin-top: 5px;
@@ -42,6 +36,12 @@ body { margin:0; padding:0; }
     font-size: 1.6rem;
     font-weight: 700;
     margin-bottom: .5rem;
+}
+.flowlistholder ul {
+    list-style-type: none;
+}
+.flowlistholder ul li {
+    margin-bottom: 0;
 }
 .flowlistholder input {
     margin-right: 5px;

--- a/src/frontend/js/index.html
+++ b/src/frontend/js/index.html
@@ -22,6 +22,30 @@ body { margin:0; padding:0; }
     float: right;
     font-size: small;
 }
+.gcvt-ctrl ul {
+    list-style-type: none;
+}
+.gcvt-ctrl ul li {
+    margin-bottom: 0;
+}
+.gcvt-ctrl button {
+    width: 100%;
+    margin-top: 5px;
+}
+.gcvt-ctrl button:first-child {
+    margin-top: 0;
+}
+.flowlistholder {
+    margin-top: 10px;
+}
+.flowlistholder span {
+    font-size: 1.6rem;
+    font-weight: 700;
+    margin-bottom: .5rem;
+}
+.flowlistholder input {
+    margin-right: 5px;
+}
 </style>
 </head>
 <body>

--- a/src/frontend/js/index.html
+++ b/src/frontend/js/index.html
@@ -49,6 +49,10 @@ body { margin:0; padding:0; }
     font-weight: 700;
     margin-bottom: .5rem;
 }
+/* mimic outlined style for select */
+.cui-select select, .cui-select select:hover {
+    background: none;
+}
 </style>
 </head>
 <body>

--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -922,20 +922,32 @@ const menuView = state => {
             // Main menu panel
             m('div', {class: 'mapboxgl-ctrl'},
                 m('div', {class: 'gcvt-ctrl', },
-                    m('label', {for: 'showctrls'}, 'Show controls: ',
-                        m('input', {name: 'showctrls', type:"checkbox", checked:state.showctrl, onchange: e => update({showctrl: e.target.checked})}),
-                    ),
-                    " ",
-                    m('a', {href: document.location.href, onclick: e => {
-                        toClipboard(e.target.href)
+                    m(UI.Button, {
+                        label: 'Copy link',
+                        fluid: true,
+                        align: 'left',
+                        basic: true,
+                        iconLeft: UI.Icons.LINK,
+                        href: document.location.href,
+                        onclick: e => {
+                            e.preventDefault()
+                            toClipboard(e.target.href)
 
-                        // Provide feedback to user
-                        e.target.innerText = "Link copied!";
-                        setTimeout(_ => e.target.innerText = "Copy link", 3000)
-
-                    }}, "Copy link"),
+                            // Provide feedback to user
+                            e.target.innerText = "Link copied!";
+                            setTimeout(_ => e.target.innerText = "Copy link", 3000)
+                        },
+                    }),
+                    m(UI.Button, {
+                        label: 'Show Controls',
+                        fluid: true,
+                        align: 'left',
+                        basic: true,
+                        iconLeft: UI.Icons.SETTINGS,
+                        iconRight: state.showctrl ? UI.Icons.CHEVRON_UP : UI.Icons.CHEVRON_DOWN,
+                        onclick: e => update({ showctrl: !state.showctrl }),
+                    }),
                     state.showctrl && state.meta.scenarios && [
-                        m('br'),
                         variableSelector(state),
                         state.layers.od_matrices.variable && [
                             scenarioSelector(state),

--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -877,14 +877,19 @@ const flowLineControls = state => {
             ),
             m('div',
                 m(UI.Button, {
-                    name: 'show_clines',
+                    label: 'Toggle Flow Lines',
+                    fluid: true,
+                    align: 'left',
+                    outlined: true,
                     onclick: e => {
                         actions.toggleCentroids(!state.showClines)
                     },
-                    label: 'Toggle Flow Lines',
                 }),
                 m(UI.Button, {
-                    name: 'deselect_zone',
+                    label: 'Deselect All',
+                    fluid: true,
+                    align: 'left',
+                    outlined: true,
                     onclick: e => {
                         update({
                             selectedZones: [],
@@ -892,7 +897,6 @@ const flowLineControls = state => {
                         })
                         actions.fetchLayerData("od_matrices")
                     },
-                    label: 'Deselect All',
                 }),
             ),
         ],
@@ -948,7 +952,7 @@ const menuView = state => {
                         label: 'Copy link',
                         fluid: true,
                         align: 'left',
-                        basic: true,
+                        outlined: true,
                         iconLeft: UI.Icons.LINK,
                         href: document.location.href,
                         onclick: e => {
@@ -964,7 +968,7 @@ const menuView = state => {
                         label: 'Show Controls',
                         fluid: true,
                         align: 'left',
-                        basic: true,
+                        outlined: true,
                         iconLeft: UI.Icons.SETTINGS,
                         iconRight: state.showctrl ? UI.Icons.CHEVRON_UP : UI.Icons.CHEVRON_DOWN,
                         onclick: e => update({ showctrl: !state.showctrl }),

--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -724,7 +724,7 @@ const { update, states, actions } =
 // HTML Views
 
 // Create an array of `option` objects for use in a `UI.Select` element.
-function meta2options(metadata, selected) {
+function meta2options(metadata) {
     return Object.entries(metadata)
         .filter(([k, v]) => v["use"] !== false)
         .map(([k, v]) => { return { value: k, label: v.name || k } })
@@ -794,7 +794,7 @@ const variableSelector = state => {
     const options = [{
         label: 'None',
         value: '',
-    }].concat(meta2options(state.meta.od_matrices, state.layers.od_matrices.variable))
+    }].concat(meta2options(state.meta.od_matrices))
 
     return [
         m('label', {for: 'matrix_variable'}, 'Variable'),
@@ -831,7 +831,8 @@ const scenarioSelector = state => {
         m(UI.Select, {
             name: 'scenario',
             fluid: true,
-            options: meta2options(scenarios_with(state.meta, state.layers.od_matrices.variable), state.scenario),
+            options: meta2options(scenarios_with(state.meta, state.layers.od_matrices.variable)),
+            defaultValue: state.scenario,
             onchange: e => actions.updateScenario(e.currentTarget.value, state.scenarioYear),
         }),
     ]
@@ -843,7 +844,8 @@ const comparisonSelector = state => {
         m(UI.Select, {
             name: 'scenario',
             fluid: true,
-            options: meta2options(scenarios_with(state.meta, state.layers.od_matrices.variable), state.compareWith),
+            options: meta2options(scenarios_with(state.meta, state.layers.od_matrices.variable)),
+            defaultValue: state.compareWith,
             onchange: e => actions.updateBaseScenario({ scenario: e.currentTarget.value })
         }),
     ]

--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -855,21 +855,24 @@ const flowLineControls = state => {
 
         state.selectedZones.length !== 0 && [
             m('div', { class: 'flowlistholder' },
-                m('span', 'Showing absolute flows for:'),
+                m('span', { class: 'flowlistheader' }, 'Showing absolute flows for:'),
                 m('ul', state.selectedZones.map(id => m('li',
-                    m(UI.Checkbox, {
-                        name: `deselect_one_${id}`,
-                        type: 'checkbox',
-                        checked: true,
-                        onchange: e => {
+                    m(UI.Button, {
+                        label: zoneToHuman(id,state),
+                        size: 'xs',
+                        fluid: true,
+                        align: 'left',
+                        basic: true,
+                        iconLeft: UI.Icons.X,
+                        onclick: e => {
                             update({
                                 selectedZones: state.selectedZones.filter(x => x != id),
                             })
                             actions.fetchLayerData('od_matrices')
                         },
-                        label: zoneToHuman(id,state),
                     }),
-                )))),
+                )))
+            ),
             m('div',
                 m(UI.Button, {
                     name: 'show_clines',

--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -791,16 +791,25 @@ document.body.appendChild(mountpoint)
 // MENU FUNCTIONS
 
 const variableSelector = state => {
+    const options = [m('option', {
+        value: '',
+        selected: state.layers.od_matrices.variable === null,
+    }, 'None')].concat(meta2options(state.meta.od_matrices, state.layers.od_matrices.variable))
+
     return [
         m('label', {for: 'matrix_variable'}, "Variable"),
         m('div[style=display:flex;align-items:center]', [
-            m('select', {
+            m(UI.Select, {
                 name: 'matrix_variable',
-                onchange: e => actions.changeLayerVariable("od_matrices", e.target.value),
-            },
-                m('option', {value: '', selected: state.layers.od_matrices.variable === null}, 'None'),
-                meta2options(state.meta.od_matrices, state.layers.od_matrices.variable)
-            ),
+                fluid: true,
+                options: options,
+                onchange: e => {
+                    // UI.Select seems to ignore the value set for an option if the option dom node has a text child
+                    // so we gotta manually switch from 'None' to null
+                    console.log(e.currentTarget)
+                    actions.changeLayerVariable("od_matrices", e.currentTarget.value === 'None' ? null : e.currentTarget.value)
+                },
+            }),
             false && (state.layers.od_matrices.variable !== "") && [
                 " ",
                 m(UI.Button, {

--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -919,21 +919,40 @@ const menuView = state => {
                         state.layers.od_matrices.variable !== "" && state.selectedZones.length == 0 && [m('br'), m('p', "(Click a zone to see outgoing flows)")],
 
                         state.selectedZones.length !== 0 && [
-                            m('label', {for: 'deselect_zone'}, 'Showing absolute flows to ', arrayToHumanList(state.selectedZones.map(id => zoneToHuman(id,state))), ' (deselect? ',
-                                m('input', {
+                            m('div', { class: 'flowlistholder' },
+                                m('span', 'Showing absolute flows for:'),
+                                m('ul', state.selectedZones.map(id => m('li',
+                                    m('input', {
+                                        name: `deselect_one_${id}`,
+                                        type: 'checkbox',
+                                        checked: true,
+                                        onchange: e => {
+                                            update({
+                                                selectedZones: state.selectedZones.filter(x => x != id),
+                                            })
+                                            actions.fetchLayerData('od_matrices')
+                                        },
+                                    }),
+                                    m('label', { for: `deselect_one_${id}` }, zoneToHuman(id,state)),
+                                )))),
+                            m('div',
+                                m('button', {
+                                    name: 'show_clines',
+                                    onclick: e => {
+                                        actions.toggleCentroids(!state.showClines)
+                                    }},
+                                    'Toggle Flow Lines'),
+                                m('button', {
                                     name: 'deselect_zone',
-                                    type:"checkbox",
-                                    checked: state.selectedZones.length == 0,
-                                    onchange: e => {
+                                    onclick: e => {
+                                        state.selectedZones.length == 0
                                         update({
                                             selectedZones: [],
                                             centroidLineWeights: null,
                                         })
                                         actions.fetchLayerData("od_matrices")
-                                    }}),
-                            ')'),
-                            m('label', {for: 'show_clines'}, 'Flow lines: ',
-                                m('input', {name: 'show_clines', type:"checkbox", checked: state.showClines, onchange: e => actions.toggleCentroids(e.target.checked)}),
+                                    }},
+                                    'Deselect'),
                             ),
                         ],
 

--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -832,7 +832,7 @@ const scenarioSelector = state => {
     ]
 }
 
-const selectionList = state => {
+const flowLineControls = state => {
     return [
         state.layers.od_matrices.variable !== "" && state.selectedZones.length == 0 && [m('br'), m('p', "(Click a zone to see outgoing flows)")],
 
@@ -972,7 +972,7 @@ const menuView = state => {
                                 }),
                             ),
 
-                            selectionList(state),
+                            flowLineControls(state),
 
                             // Summary statistics for zones
                             state.layers.od_matrices.variable !== ""

--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -922,7 +922,7 @@ const menuView = state => {
                             m('div', { class: 'flowlistholder' },
                                 m('span', 'Showing absolute flows for:'),
                                 m('ul', state.selectedZones.map(id => m('li',
-                                    m('input', {
+                                    m(UI.Checkbox, {
                                         name: `deselect_one_${id}`,
                                         type: 'checkbox',
                                         checked: true,
@@ -932,27 +932,28 @@ const menuView = state => {
                                             })
                                             actions.fetchLayerData('od_matrices')
                                         },
+                                        label: zoneToHuman(id,state),
                                     }),
-                                    m('label', { for: `deselect_one_${id}` }, zoneToHuman(id,state)),
                                 )))),
                             m('div',
-                                m('button', {
+                                m(UI.Button, {
                                     name: 'show_clines',
                                     onclick: e => {
                                         actions.toggleCentroids(!state.showClines)
-                                    }},
-                                    'Toggle Flow Lines'),
-                                m('button', {
+                                    },
+                                    label: 'Toggle Flow Lines',
+                                }),
+                                m(UI.Button, {
                                     name: 'deselect_zone',
                                     onclick: e => {
-                                        state.selectedZones.length == 0
                                         update({
                                             selectedZones: [],
                                             centroidLineWeights: null,
                                         })
                                         actions.fetchLayerData("od_matrices")
-                                    }},
-                                    'Deselect'),
+                                    },
+                                    label: 'Deselect All',
+                                }),
                             ),
                         ],
 

--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -970,26 +970,19 @@ const menuView = state => {
                             scenarioSelector(state),
 
                             // Show compare with button if there's more than one scenario featuring this variable
-                            R.length(R.keys(scenarios_with(state.meta, state.layers.od_matrices.variable))) > 1 &&
-                            m('label', {for: 'compare'}, 'Compare with: ',
-                                m('input', {
-                                    name: 'compare',
-                                    type:"checkbox",
-                                    checked: state.compare,
-                                    onchange: e => actions.setCompare(e.target.checked),
-                                }),
-                            ),
+                            R.length(R.keys(scenarios_with(state.meta, state.layers.od_matrices.variable))) > 1 && m(UI.Switch, {
+                                label: 'Compare Scenarios',
+                                checked: state.compare,
+                                onchange: e => actions.setCompare(e.target.checked),
+                            }),
 
                             state.meta.scenarios && state.compare && comparisonSelector(state),
 
-                            state.compare && m('label', {for: 'percent'}, 'Percentage difference: ',
-                                m('input', {
-                                    name: 'percent',
-                                    type:"checkbox",
-                                    checked: state.percent,
-                                    onchange: e => actions.setPercent(e.target.checked),
-                                }),
-                            ),
+                            state.compare && m(UI.Switch, {
+                                label: 'Show As Percentage',
+                                checked: state.percent,
+                                onchange: e => actions.setPercent(e.target.checked),
+                            }),
 
                             flowLineControls(state),
 

--- a/src/frontend/js/index.js
+++ b/src/frontend/js/index.js
@@ -954,11 +954,8 @@ const menuView = state => {
                         align: 'left',
                         outlined: true,
                         iconLeft: UI.Icons.LINK,
-                        href: document.location.href,
                         onclick: e => {
-                            e.preventDefault()
-                            toClipboard(e.target.href)
-
+                            toClipboard(document.location.href)
                             // Provide feedback to user
                             e.target.innerText = "Link copied!";
                             setTimeout(_ => e.target.innerText = "Copy link", 3000)

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -17,7 +17,6 @@
     "mapbox-gl": "^1.5.0",
     "meiosis-setup": "^3.1.0",
     "mergerino": "^0.4.0",
-    "milligram": "^1.3.0",
     "mithril": "^2.0.4",
     "mithril-n": "^1.0.1",
     "parcel": "^1.12.4",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -18,9 +18,7 @@
     "meiosis-setup": "^3.1.0",
     "mergerino": "^0.4.0",
     "mithril": "^2.0.4",
-    "mithril-n": "^1.0.1",
     "parcel": "^1.12.4",
-    "ramda": "^0.26.1",
-    "typescript": "^3.7.2"
+    "ramda": "^0.26.1"
   }
 }

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -4817,24 +4817,12 @@ minizlib@^1.2.1:
   dependencies:
     minipass "^2.9.0"
 
-mithril-n@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mithril-n/-/mithril-n-1.0.1.tgz#b8687f7b549ecdd7692188c324d589a86a3ec665"
-  integrity sha1-uGh/e1SezddpIYjDJNWJqGo+xmU=
-  dependencies:
-    mithril ">=0.1.0 <0.3.0"
-
 mithril-transition-group@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/mithril-transition-group/-/mithril-transition-group-0.1.7.tgz#5616dccb49539d206cc6bd169a7a6c86dbdd42c3"
   integrity sha512-czckLLvNcjBLmUmJQJr8kt+AkmJG6wr5lU43MGoC53qvbc942Q8MCXbJkyKtqOpMqzfAnek7T3z35dumTdFmMw==
   dependencies:
     element-class "^0.2.2"
-
-"mithril@>=0.1.0 <0.3.0":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/mithril/-/mithril-0.2.8.tgz#cc6d470b9227cebb342718655bd0a1d7ab2afb96"
-  integrity sha512-9XuGnVmS2OyFexUuP/CcJFFJjHLM+RGYBxyVRNyQ6khbMfDJIF/xyZ4zq18ZRfPagpFmWUFpjHd5ZqPULGZyNg==
 
 mithril@^2.0.4:
   version "2.0.4"
@@ -6833,11 +6821,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uncss@^0.17.0:
   version "0.17.2"

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -4748,13 +4748,6 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-milligram@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/milligram/-/milligram-1.3.0.tgz#a5d980ef8eaf79337c96a8d7c7e176764931042c"
-  integrity sha1-pdmA746veTN8lqjXx+F2dkkxBCw=
-  dependencies:
-    normalize.css "~5.0.0"
-
 mime-db@1.40.0:
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
@@ -5017,11 +5010,6 @@ normalize-url@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
-
-normalize.css@~5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-5.0.0.tgz#7cec875ce8178a5333c4de80b68ea9c18b9d7c37"
-  integrity sha1-fOyHXOgXilMzxN6Ato6pwYudfDc=
 
 npm-bundled@^1.0.1:
   version "1.0.6"


### PR DESCRIPTION
Reworked the zone selection list to be (hopefully) more readable/usable. Current selections now appear as an actual list, each item has its own individual selection checkbox, and the old checkboxes have been replaced with buttons. Looks like this:

![210211-181949](https://user-images.githubusercontent.com/8337473/107680529-e00ff080-6c95-11eb-89c3-7cac92bc82df.png)
